### PR TITLE
k8s output

### DIFF
--- a/cmd/nddscalegen/generate.go
+++ b/cmd/nddscalegen/generate.go
@@ -1,7 +1,10 @@
 package nddscalegen
 
 import (
+	"bytes"
+
 	"gihub.com/yndd/ndd-scale-test/pkg/generator"
+	"gihub.com/yndd/ndd-scale-test/pkg/output"
 	"github.com/spf13/cobra"
 	"github.com/yndd/ndd-runtime/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -12,13 +15,14 @@ var (
 	count        int
 	outputDir    string
 	templateFile string
+	kubeconfig   string
 )
 
-// generateCmd represents the generate command
-var generateCmd = &cobra.Command{
-	Use:          "generate",
-	Short:        "generate ndd scale templates",
-	Aliases:      []string{"gen"},
+// fileCommand represents the generate command
+var fileCommand = &cobra.Command{
+	Use:   "file",
+	Short: "generate ndd scale yaml files from template",
+	//Aliases:      []string{"gen"},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		zlog := zap.New(zap.UseDevMode(true), zap.JSONEncoder())
@@ -27,15 +31,24 @@ var generateCmd = &cobra.Command{
 
 		g, err := generator.NewGenerator(
 			generator.WithIndexes(offset, count),
-			generator.WithOutputDir(outputDir),
 			generator.WithTemplate(templateFile),
 		)
 		if err != nil {
 			return err
 		}
 
-		if err := g.Run(); err != nil {
+		var data []*bytes.Buffer
+		if data, err = g.Generate(); err != nil {
 			return err
+		}
+
+		outputPlugin := output.NewFileOutput(outputDir)
+
+		for k, v := range data {
+			err = outputPlugin.Commit(v, &output.OutputPluginInfo{Index: k})
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -43,9 +56,96 @@ var generateCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(generateCmd)
-	generateCmd.Flags().IntVarP(&offset, "offset", "o", 100, "The offset of the index")
-	generateCmd.Flags().IntVarP(&count, "count", "c", 10, "The number of templates generated")
-	generateCmd.Flags().StringVarP(&templateFile, "templateFile", "t", "./templates/irb.tmpl", "the template used for the scale test generation")
-	generateCmd.Flags().StringVarP(&outputDir, "output-dir", "", "out/", "The directory that the Go package should be written to.")
+	rootCmd.AddCommand(fileCommand)
+	rootCmd.AddCommand(k8sCommand)
+	k8sCommand.AddCommand(k8sAddCommand)
+	k8sCommand.AddCommand(k8sDeleteCommand)
+	k8sCommand.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "kubeconfig file")
+
+	rootCmd.PersistentFlags().IntVarP(&offset, "offset", "o", 0, "The offset of the index")
+	rootCmd.PersistentFlags().IntVarP(&count, "count", "c", 1, "The number of templates generated")
+	rootCmd.PersistentFlags().StringVarP(&templateFile, "templateFile", "t", "./templates/irb.tmpl", "the template used for the scale test generation")
+	fileCommand.Flags().StringVarP(&outputDir, "output-dir", "", "out/", "The directory that the Go package should be written to.")
+}
+
+// k8sCommand represents the generate command
+var k8sCommand = &cobra.Command{
+	Use:          "k8s",
+	Short:        "generate CustomResources from template and commit them to the api-server",
+	Aliases:      []string{"k"},
+	SilenceUsage: false,
+}
+
+// k8sCommand represents the generate command
+var k8sDeleteCommand = &cobra.Command{
+	Use:          "delete",
+	Short:        "generate CustomResources from template and use the names to delete them from the api-server",
+	Aliases:      []string{"d"},
+	SilenceUsage: false,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		zlog := zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+		log := logging.NewLogrLogger(zlog.WithName("nddscalegen"))
+		log.Debug("generate nddscalegen templates ...")
+
+		g, err := generator.NewGenerator(
+			generator.WithIndexes(offset, count),
+			generator.WithTemplate(templateFile),
+		)
+		if err != nil {
+			return err
+		}
+
+		var data []*bytes.Buffer
+		if data, err = g.Generate(); err != nil {
+			return err
+		}
+
+		outputPlugin := output.NewK8sOutput(kubeconfig)
+
+		for k, v := range data {
+			err = outputPlugin.Delete(v, &output.OutputPluginInfo{Index: k})
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
+}
+
+// k8sCommand represents the generate command
+var k8sAddCommand = &cobra.Command{
+	Use:          "commit",
+	Short:        "generate CustomResources from template and commit them to the api-server",
+	Aliases:      []string{"c"},
+	SilenceUsage: false,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		zlog := zap.New(zap.UseDevMode(true), zap.JSONEncoder())
+		log := logging.NewLogrLogger(zlog.WithName("nddscalegen"))
+		log.Debug("generate nddscalegen templates ...")
+
+		g, err := generator.NewGenerator(
+			generator.WithIndexes(offset, count),
+			generator.WithTemplate(templateFile),
+		)
+		if err != nil {
+			return err
+		}
+
+		var data []*bytes.Buffer
+		if data, err = g.Generate(); err != nil {
+			return err
+		}
+
+		outputPlugin := output.NewK8sOutput(kubeconfig)
+
+		for k, v := range data {
+			err = outputPlugin.Commit(v, &output.OutputPluginInfo{Index: k})
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,21 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/sys v0.0.0-20211205182925-97ca703d548d // indirect
+	golang.org/x/term v0.0.0-20210916214954-140adaaadfaf // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/api v0.23.3 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
+)
+
+require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/go-logr/logr v1.2.0 // indirect
@@ -36,9 +51,10 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apimachinery v0.23.0 // indirect
+	k8s.io/apimachinery v0.23.3
+	k8s.io/client-go v0.23.3
 	k8s.io/klog/v2 v2.30.0 // indirect
-	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b // indirect
+	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.2.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -501,6 +501,7 @@ github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
@@ -643,6 +644,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -722,6 +724,7 @@ github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pf
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
+github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -1618,6 +1621,7 @@ golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210805134026-6f1e6394065a/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
 golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1764,6 +1768,7 @@ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXR
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20210916214954-140adaaadfaf h1:Ihq/mm/suC88gF8WFcVwk+OV6Tq+wyA1O0E5UEvDglI=
 golang.org/x/term v0.0.0-20210916214954-140adaaadfaf/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1783,6 +1788,7 @@ golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -1919,6 +1925,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -2054,6 +2061,7 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -2128,8 +2136,9 @@ k8s.io/api v0.21.2/go.mod h1:Lv6UGJZ1rlMI1qusN8ruAp9PUBFyBwpEHAdG24vIsiU=
 k8s.io/api v0.21.3/go.mod h1:hUgeYHUbBp23Ue4qdX9tR8/ANi/g3ehylAqDn9NWVOg=
 k8s.io/api v0.22.1/go.mod h1:bh13rkTp3F1XEaLGykbyRD2QaTTzPm0e/BMd8ptFONY=
 k8s.io/api v0.22.2/go.mod h1:y3ydYpLJAaDI+BbSe2xmGcqxiWHmWjkEeIbiwHvnPR8=
-k8s.io/api v0.23.0 h1:WrL1gb73VSC8obi8cuYETJGXEoFNEh3LU0Pt+Sokgro=
 k8s.io/api v0.23.0/go.mod h1:8wmDdLBHBNxtOIytwLstXt5E9PddnZb0GaMcqsvDBpg=
+k8s.io/api v0.23.3 h1:KNrME8KHGr12Ozjf8ytOewKzZh6hl/hHUZeHddT3a38=
+k8s.io/api v0.23.3/go.mod h1:w258XdGyvCmnBj/vGzQMj6kzdufJZVUwEM1U2fRJwSQ=
 k8s.io/apiextensions-apiserver v0.21.2/go.mod h1:+Axoz5/l3AYpGLlhJDfcVQzCerVYq3K3CvDMvw6X1RA=
 k8s.io/apiextensions-apiserver v0.22.1/go.mod h1:HeGmorjtRmRLE+Q8dJu6AYRoZccvCMsghwS8XTUYb2c=
 k8s.io/apiextensions-apiserver v0.23.0/go.mod h1:xIFAEEDlAZgpVBl/1VSjGDmLoXAWRG40+GsWhKhAxY4=
@@ -2142,8 +2151,9 @@ k8s.io/apimachinery v0.21.2/go.mod h1:CdTY8fU/BlvAbJ2z/8kBwimGki5Zp8/fbVuLY8gJum
 k8s.io/apimachinery v0.21.3/go.mod h1:H/IM+5vH9kZRNJ4l3x/fXP/5bOPJaVP/guptnZPeCFI=
 k8s.io/apimachinery v0.22.1/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
 k8s.io/apimachinery v0.22.2/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
-k8s.io/apimachinery v0.23.0 h1:mIfWRMjBuMdolAWJ3Fd+aPTMv3X9z+waiARMpvvb0HQ=
 k8s.io/apimachinery v0.23.0/go.mod h1:fFCTTBKvKcwTPFzjlcxp91uPFZr+JA0FubU4fLzzFYc=
+k8s.io/apimachinery v0.23.3 h1:7IW6jxNzrXTsP0c8yXz2E5Yx/WTzVPTsHIx/2Vm0cIk=
+k8s.io/apimachinery v0.23.3/go.mod h1:BEuFMMBaIbcOqVIJqNZJXGFTP4W6AycEpb5+m/97hrM=
 k8s.io/apiserver v0.19.7/go.mod h1:DmWVQggNePspa+vSsVytVbS3iBSDTXdJVt0akfHacKk=
 k8s.io/apiserver v0.20.1/go.mod h1:ro5QHeQkgMS7ZGpvf4tSMx6bBOgPfE+f52KwvXfScaU=
 k8s.io/apiserver v0.20.4/go.mod h1:Mc80thBKOyy7tbvFtB4kJv1kbdD0eIH8k8vianJcbFM=
@@ -2160,6 +2170,8 @@ k8s.io/client-go v0.21.3/go.mod h1:+VPhCgTsaFmGILxR/7E1N0S+ryO010QBeNCv5JwRGYU=
 k8s.io/client-go v0.22.1/go.mod h1:BquC5A4UOo4qVDUtoc04/+Nxp1MeHcVc1HJm1KmG8kk=
 k8s.io/client-go v0.22.2/go.mod h1:sAlhrkVDf50ZHx6z4K0S40wISNTarf1r800F+RlCF6U=
 k8s.io/client-go v0.23.0/go.mod h1:hrDnpnK1mSr65lHHcUuIZIXDgEbzc7/683c6hyG4jTA=
+k8s.io/client-go v0.23.3 h1:23QYUmCQ/W6hW78xIwm3XqZrrKZM+LWDqW2zfo+szJs=
+k8s.io/client-go v0.23.3/go.mod h1:47oMd+YvAOqZM7pcQ6neJtBiFH7alOyfunYN48VsmwE=
 k8s.io/cloud-provider v0.19.7/go.mod h1:aO/VpUwkG+JQN7ZXc5WBLZ5NBXuq/Y5B6vri6U94PZ8=
 k8s.io/code-generator v0.19.7/go.mod h1:lwEq3YnLYb/7uVXLorOJfxg+cUu2oihFhHZ0n9NIla0=
 k8s.io/code-generator v0.21.2/go.mod h1:8mXJDCB7HcRo1xiEQstcguZkbxZaqeUOrO9SsicWs3U=
@@ -2197,6 +2209,7 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kube-openapi v0.0.0-20210113233702-8566a335510f/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
+k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 h1:E3J9oCLlaobFUqsjG9DfKbP2BmgwBL2p7pn0A3dG9W4=
 k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65/go.mod h1:sX9MT8g7NVZM5lVL/j8QyCCJe8YSMW30QvGZWaCIDIk=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/legacy-cloud-providers v0.19.7/go.mod h1:dsZk4gH9QIwAtHQ8CK0Ps257xlfgoXE3tMkMNhW2xDU=
@@ -2207,8 +2220,9 @@ k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b h1:wxEMGetGMur3J1xuGLQY7GEQYg9bZxKn3tKo5k/eYcs=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20211116205334-6203023598ed h1:ck1fRPWPJWsMd8ZRFsWc6mh/zHp5fZ/shhbrgPUxDAE=
+k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 pack.ag/amqp v0.11.2/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
@@ -2233,8 +2247,9 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
-sigs.k8s.io/structured-merge-diff/v4 v4.2.0 h1:kDvPBbnPk+qYmkHmSo8vKGp438IASWofnbbUKDE/bv0=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.0/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
+sigs.k8s.io/structured-merge-diff/v4 v4.2.1 h1:bKCqE9GvQ5tiVHn5rfn1r+yao3aLQEaLzkkmAkf+A6Y=
+sigs.k8s.io/structured-merge-diff/v4 v4.2.1/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=

--- a/pkg/output/file_output.go
+++ b/pkg/output/file_output.go
@@ -1,0 +1,41 @@
+package output
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+type FileOutput struct {
+	outDir string
+}
+
+func NewFileOutput(outDir string) *FileOutput {
+	return &FileOutput{
+		outDir: outDir,
+	}
+}
+
+func (fo *FileOutput) Commit(data *bytes.Buffer, opi *OutputPluginInfo) error {
+	f, err := os.Create(filepath.Join(fo.outDir, "nddtest-"+strconv.Itoa(opi.Index)+".yaml"))
+	if err != nil {
+		return err
+	}
+
+	_, err = data.WriteTo(f)
+	if err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (fo *FileOutput) Delete(data *bytes.Buffer, opi *OutputPluginInfo) error {
+	return fmt.Errorf("Not implemented")
+}

--- a/pkg/output/k8sapi_output.go
+++ b/pkg/output/k8sapi_output.go
@@ -1,0 +1,166 @@
+package output
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+type K8sApiOutput struct {
+	client       dynamic.Interface
+	mapper       *restmapper.DeferredDiscoveryRESTMapper
+	committedCRs []*CommittedCR
+	kubeconfig   string
+}
+
+type CommittedCR struct {
+	data    *unstructured.Unstructured
+	index   int
+	mapping *meta.RESTMapping
+}
+
+func NewK8sOutput(kubeconfig string) *K8sApiOutput {
+	result := &K8sApiOutput{
+		client:       nil,
+		mapper:       nil,
+		committedCRs: []*CommittedCR{},
+	}
+	if kubeconfig != "" {
+		result.kubeconfig = kubeconfig
+	}
+	return result
+}
+
+func (k *K8sApiOutput) Commit(data *bytes.Buffer, opi *OutputPluginInfo) error {
+
+	err := k.init()
+	if err != nil {
+		return err
+	}
+
+	apiinfo, err := k.k8sCreate(data)
+	if err != nil {
+		return err
+	}
+
+	k.committedCRs = append(k.committedCRs, &CommittedCR{
+		data:    apiinfo.obj,
+		index:   opi.Index,
+		mapping: apiinfo.restmapping,
+	})
+
+	return nil
+}
+
+func (k *K8sApiOutput) Delete(data *bytes.Buffer, opi *OutputPluginInfo) error {
+	err := k.init()
+	if err != nil {
+		return err
+	}
+
+	err = k.k8sDelete(data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func deduceApiInformation(b *bytes.Buffer, mapper *restmapper.DeferredDiscoveryRESTMapper) (*ApiInfos, error) {
+	obj := &unstructured.Unstructured{}
+
+	// decode YAML into unstructured.Unstructured
+	dec := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	_, gvk, err := dec.Decode(b.Bytes(), nil, obj)
+	if err != nil {
+		return nil, err
+	}
+
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceValue := obj.GetNamespace()
+
+	return &ApiInfos{namespace: namespaceValue, restmapping: mapping, obj: obj}, nil
+}
+
+type ApiInfos struct {
+	namespace   string
+	restmapping *meta.RESTMapping
+	obj         *unstructured.Unstructured
+}
+
+func (k *K8sApiOutput) k8sCreate(b *bytes.Buffer) (*ApiInfos, error) {
+
+	apiinfo, err := deduceApiInformation(b, k.mapper)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("Creating %s of Kind %s in %s\n", apiinfo.obj.GetName(), apiinfo.obj.GetKind(), apiinfo.namespace)
+	_, err = k.client.Resource(apiinfo.restmapping.Resource).Namespace(apiinfo.namespace).Create(context.TODO(), apiinfo.obj, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return apiinfo, nil
+}
+
+func (k *K8sApiOutput) k8sDelete(b *bytes.Buffer) error {
+	apiinfo, err := deduceApiInformation(b, k.mapper)
+	if err != nil {
+		return err
+	}
+
+	err = k.client.Resource(apiinfo.restmapping.Resource).Namespace(apiinfo.namespace).Delete(context.TODO(), apiinfo.obj.GetName(), metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// init initializes the kubernetes client
+func (k *K8sApiOutput) init() error {
+
+	// initialize if not yet done!
+	if k.client != nil {
+		return nil
+	}
+
+	kubeconfig := k.kubeconfig
+	if kubeconfig == "" {
+		home := homedir.HomeDir()
+		kubeconfig = filepath.Join(home, ".kube", "config")
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return err
+	}
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	k.client = client
+
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return err
+	}
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+
+	k.mapper = mapper
+	return nil
+}

--- a/pkg/output/output_interface.go
+++ b/pkg/output/output_interface.go
@@ -1,0 +1,15 @@
+package output
+
+import (
+	"bytes"
+)
+
+type OutputPlugin interface {
+	Commit(data *bytes.Buffer, opi *OutputPluginInfo) error
+	Delete(data *bytes.Buffer, opi *OutputPluginInfo) error
+}
+
+type OutputPluginInfo struct {
+	Index   int
+	Outname string
+}


### PR DESCRIPTION
allows for `file` or `k8s` subcommands now.
file continues to generate files in the output folder. K8s pushes the template generated CRs straight to the api-server.
`k8s` further branches into a `commit `and a `delete` command.
commit created the CRs while delete is used to generate the template first but then use the generated yaml to delete the CRs from the api-server.